### PR TITLE
chore: deleted consoles and ajust in pdi alert

### DIFF
--- a/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
+++ b/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
@@ -500,7 +500,18 @@ export function ReviewScaleAndCriteriaForm() {
 
         fetchEvidences();
     }, [])
-    console.log(evidenceDataList);
+
+    function formatDate(dateString) {
+        const date = new Date(dateString);
+        const adjustedDate = new Date(date.getTime() + date.getTimezoneOffset() * 60000);
+
+        const day = String(adjustedDate.getDate()).padStart(2, '0');
+        const month = String(adjustedDate.getMonth() + 1).padStart(2, '0');
+        const year = adjustedDate.getFullYear();
+
+        return `${day}/${month}/${year}`;
+    }
+
     if (isLoadingReviewScaleAndCriteriaData) {
         return (
             <PageChange />
@@ -557,9 +568,9 @@ export function ReviewScaleAndCriteriaForm() {
                                             <Table className="align-items-center table-flush" responsive>
                                                 <thead className="thead-light">
                                                     <tr>
-                                                        <th>Evidência</th>
                                                         <th>Descrição</th>
                                                         <th>Status</th>
+                                                        <th>Adicionada Em</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -568,9 +579,9 @@ export function ReviewScaleAndCriteriaForm() {
                                                             .filter(evidence => evidence.evidenceName == competency.id)
                                                             .map(evidence => (
                                                                 <tr key={evidence.id}>
-                                                                    <td>{evidence.evidenceName}</td>
-                                                                    <td>{evidence.description || "Carregando..."}</td>
+                                                                    <td>{evidence.description ?? "Carregando..."}</td>
                                                                     <td>{evidence.status ? "Ativo" : "Inativo"}</td>
+                                                                    <td>{formatDate(evidence.createdAt) ?? "Não informado"}</td>
                                                                 </tr>
                                                             ))
                                                     ) : (

--- a/components/Tables/PDI/CompetenciesList.js
+++ b/components/Tables/PDI/CompetenciesList.js
@@ -36,7 +36,6 @@ function CompetenciesList({ handleShowCompetencieRegister }) {
     const [userCompetenciesAccountData, setUserCompetenciesAccountData] = useState([]);
 
     function handleCompetenciesUpdate(competencieId) {
-        console.log(competencieId);
         handleCompetenciesIdToUpdate(competencieId);
         handleOpenCompetenciesUpdateModal();
     }
@@ -82,7 +81,6 @@ function CompetenciesList({ handleShowCompetencieRegister }) {
     const [competencieDeleteError, setCompetencieDeleteError] = useState(null);
 
     const handleDeleteCompetencie = async (competencieId) => {
-        console.log(competencieId);
         if (competencieId) {
             try {
                 const deleteResponse = await useDeleteCompetencies(competencieId);
@@ -99,12 +97,12 @@ function CompetenciesList({ handleShowCompetencieRegister }) {
         }
     };
 
-    const showWarningAlert = (competencieId) => {
+    const showWarningAlert = (competencieId, competencieName) => {
         warningAlert(
             `${competencieId}`,
             "Atenção",
             "Deletar",
-            `Você deseja realmente excluir ${competencieId}?`,
+            `Você deseja realmente excluir ${competencieName}?`,
             "lg",
             () => handleDeleteCompetencie(competencieId)
         );
@@ -181,7 +179,7 @@ function CompetenciesList({ handleShowCompetencieRegister }) {
                                         </DropdownItem>
                                         <DropdownItem
                                             href="#pablo"
-                                            onClick={(e) => { e.preventDefault(); showWarningAlert(competencies.id); }}
+                                            onClick={(e) => { e.preventDefault(); showWarningAlert(competencies.id , competencies.name); }}
                                         >
                                             Deletar
                                         </DropdownItem>

--- a/components/Tables/PDI/PDIList.js
+++ b/components/Tables/PDI/PDIList.js
@@ -61,7 +61,6 @@ export function PDIList() {
     }
 
     function handleShowPdiDetailsModal(pdiId) {
-        console.log(pdiId);
         setSelectedIdToShowPdiDetails(pdiId);
         handleOpenPdiModal();
     }
@@ -142,12 +141,12 @@ export function PDIList() {
         }
     }, [pdiDeleteSuccess]);
 
-    const showWarningAlert = (pdiId) => {
+    const showWarningAlert = (pdiId, pdiName) => {
         warningAlert(
             `${pdiId}`,
             "Atenção",
             "Deletar",
-            `Você deseja realmente excluir ${pdiId}?`,
+            `Você deseja realmente excluir ${pdiName}?`,
             "lg",
             () => handleDeletePdi(pdiId)
         );
@@ -240,7 +239,7 @@ export function PDIList() {
                                         </DropdownItem>
                                         <DropdownItem
                                             href="#pablo"
-                                            onClick={(e) => { e.preventDefault(); showWarningAlert(pdi.id); }}
+                                            onClick={(e) => { e.preventDefault(); showWarningAlert(pdi.id, pdi.name); }}
                                         >
                                             Deletar
                                         </DropdownItem>

--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -14,7 +14,7 @@ function AuthProvider({ children }) {
     }
 
     TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT = authenticationDataLoggedInUser.role;
-    console.log("TypeUser no AuthContext :",TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT);
+
     return (
         <AuthContext.Provider
             value={{

--- a/hooks/RecordsHooks/pdi/competencies/useUpdateCompetencies.js
+++ b/hooks/RecordsHooks/pdi/competencies/useUpdateCompetencies.js
@@ -58,7 +58,7 @@ const useUpdateCompetencies = () => {
                 });
 
                 if (response.ok) {
-                    console.log('Data sent successfully!');
+                    // console.log('Data sent successfully!');
                     setCompetencieUpdateSuccess("Competência atualizada com sucesso!");
                 } else {
                     console.error('Error in response:', response.status);

--- a/hooks/RecordsHooks/pdi/useUpdatePdi.js
+++ b/hooks/RecordsHooks/pdi/useUpdatePdi.js
@@ -124,7 +124,7 @@ const useUpdatePdi = () => {
                     payloadCompetencies.competencies = competencies;
                 };
 
-                console.log(payload);
+                // console.log(payload);
                 
                 const response = await fetch(`${process.env.NEXT_PUBLIC_PDI}/${pdiIdToUpdate}`, {
                     method: 'PATCH',
@@ -143,13 +143,13 @@ const useUpdatePdi = () => {
                 });
 
                 if (responseCompetencies.ok) {
-                    console.log('Competencia editada!');
+                    // console.log('Competencia editada!');
                 } else {
                     console.error('Erro em editar a competencia:', response.status);
                 }
 
                 if (response.ok) {
-                    console.log('Data sent successfully!');
+                    // console.log('Data sent successfully!');
                 } else {
                     console.error('Error in response:', response.status);
                 }

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -4,6 +4,6 @@ import { AuthContext } from '../contexts/AuthContext';
 
 export function useAuth() {
     const context = useContext(AuthContext);
-    console.log("contex do useAuth :", context);
+
     return context;
 }

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -83,7 +83,6 @@ function Login() {
 
     const isEmailValid = await validateEmailInSystem(formData.email);
     if (isEmailValid) {
-      console.log('Enviar email de recuperação para:', formData.email);
       setFormLogin(false);
       setForgotPassword(true);
       setEmailForgot(false);
@@ -182,24 +181,19 @@ function Login() {
         const data = await response.json();
         handleSaveAuthenticationDataLoggedInUser(data);
         handleCustomerIdToLinkToEmployee(data.data.id);
-        console.log(data);
         let redirectUrl = `${process.env.NEXT_PUBLIC_HOME_PAGE}`;
 
         switch (data.role) {
           case 'administrator':
-            console.log('Redirecionando para o painel do administrador');
             redirectUrl += '/dashboard/admin';
             break;
           case 'customer':
-            console.log('Redirecionando para o painel da empresa');
             redirectUrl += '/dashboard/customer';
             break;
           case 'employee':
-            console.log('Redirecionando para o perfil do funcionário');
             redirectUrl += '/employee/profile';
             break;
           default:
-            console.log('Redirecionando para a página padrão');
             redirectUrl = `${process.env.NEXT_PUBLIC_HOME_PAGE}/default`;
         }
 

--- a/pages/pdi/add-pdi.js
+++ b/pages/pdi/add-pdi.js
@@ -48,7 +48,6 @@ function AddPDI() {
         </>
     );
 }
-console.log("typeUser :", TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT);
 
 TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
     ? AddPDI.layout = Admin
@@ -57,6 +56,5 @@ TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
         : (TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'employee'
             ? AddPDI.layout = Employee
             : AddPDI.layout = Admin));
-// AddPDI.layout = Performance;
 
 export default AddPDI;

--- a/pages/pdi/competencies-pdi.js
+++ b/pages/pdi/competencies-pdi.js
@@ -57,7 +57,6 @@ function CompetenciesPDI() {
         </>
     );
 }
-console.log("typeUser :", TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT);
 
 TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
     ? CompetenciesPDI.layout = Admin
@@ -66,6 +65,5 @@ TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
         : (TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'employee'
             ? CompetenciesPDI.layout = Employee
             : CompetenciesPDI.layout = Admin));
-// CompetenciesPDI.layout = Performance;
 
 export default CompetenciesPDI;

--- a/pages/pdi/dashboard-pdi.js
+++ b/pages/pdi/dashboard-pdi.js
@@ -39,8 +39,6 @@ function DashboardPDI() {
     );
 }
 
-console.log("typeUser :", TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT);
-
 TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
     ? DashboardPDI.layout = Admin
     : (TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'customer'
@@ -48,6 +46,5 @@ TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'administrator'
         : (TYPE_USER_ACCESS_DEFINES_PAGE_LAYOUT === 'employee'
             ? DashboardPDI.layout = Employee
             : DashboardPDI.layout = Admin));
-// DashboardPDI.layout = Performance;
 
 export default DashboardPDI;


### PR DESCRIPTION
Removi alguns consoles que havia colocado ontem e também nas telas de pdi. Ajustei o alert que antes estava mostrando o id da competência/pdi para deletar agora mostra o nome. Ajustei a table das evidências de avaliação estava mostrando uma coluna do id e removi ela e adicionei uma coluna de quando foi criado.