### PR TITLE
Pr ava comp

### DIFF
--- a/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
+++ b/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
@@ -64,27 +64,32 @@ export function ReviewScaleAndCriteriaForm() {
     const [selectedIds, setSelectedIds] = useState([]);
 
     // Configuração para seleção de linhas
-    const selectRow = {
-        mode: "checkbox", // Alternativa: "radio" para seleção única
-        clickToSelect: true, // Permite selecionar clicando na linha
+    const selectRow = (competenceId) => ({
+        mode: "checkbox",
+        clickToSelect: true,
         onSelect: (row, isSelected) => {
-            dispatch({
-                type: "SET_REVIEW_EVIDENCE_DATA_LIST",
-                payload: (prevState) => {
-                    const currentList = prevState.reviewScaleAndCriteriaData.reviewEvidenceData;
-                    if (isSelected) {
-                        return [...currentList, row]; // Adiciona o item selecionado
-                    }
-                    return currentList.filter((item) => item.id !== row.id); // Remove o item desmarcado
-                },
-            });
+            console.log(row, isSelected, competenceId);
+            if (isSelected) {
+                dispatch({ type: "SET_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
+            } else {
+                dispatch({ type: "REMOVE_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
+            }
         },
         onSelectAll: (isSelect, rows) => {
-            dispatch({
-                type: "SET_REVIEW_EVIDENCE_DATA_LIST",
-                payload: isSelect ? rows : [], // Seleciona todos ou limpa
-            });
-        },
+            if (isSelect) {
+                rows.forEach(row => {
+                    dispatch({ type: "SET_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
+                });
+            } else {
+                rows.forEach(row => {
+                    dispatch({ type: "REMOVE_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
+                });
+            }
+        }
+    });
+
+    const removeCompetence = (competenceId) => {
+        dispatch({ type: 'REMOVE_REVIEW_COMPETENCE', payload: { competenceId } });
     };
 
     // Colunas da tabela de evidências 
@@ -318,6 +323,9 @@ export function ReviewScaleAndCriteriaForm() {
                         });
 
                         latestreviewScaleAndCriteriaData.current = parsedData; // Atualiza a ref para os dados carregados
+
+                        // setCompetencies(parsedData.reviewCompetenceEvidenceData);
+                        console.log("parsedData", parsedData.reviewCompetenceEvidenceData);
                     }
                 } else {
                     dispatch({ type: 'RESET_REVIEW_STATE' }); // Limpa o estado para evitar inconsistências
@@ -356,8 +364,10 @@ export function ReviewScaleAndCriteriaForm() {
     }, [state.reviewScaleAndCriteriaData]);
 
     const [competencies, setCompetencies] = useState([]);
+
     const [competenciesDataList, setCompetenciesDataList] = useState([]);
     const [competenciesDetails, setCompetenciesDetails] = useState([]);
+    
     const [occupationalGroups, setOccupationalGroups] = useState([]);
     const [skillClassifications, setSkillClassifications] = useState([]);
     const [evidenceDataList, setEvidenceDataList] = useState([]);
@@ -388,28 +398,26 @@ export function ReviewScaleAndCriteriaForm() {
     }, [competencies]);
 
     const handleCompetenciesChange = (e) => {
-        const selectedCompetencies = Array.from(e.target.selectedOptions).map((option) =>
-            Number(option.value)
-        );
+        const selectedCompetencies = Array.from(e.target.selectedOptions).map(option => Number(option.value));
 
-        const formattedCompetencies = selectedCompetencies.map((competencyId) => ({
-            idCompence: competencyId,
-            evidences: evidenceDataList
-                .filter((evidence) => evidence.evidenceName == competencyId)
-                .map((evidence) => ({ idEvidence: evidence.id })),
-        }));
+        console.log("selectedCompetencies",selectedCompetencies);
 
         setCompetencies(selectedCompetencies);
-        dispatch({ type: 'SET_REVIEW_COMPETENCIE_DATA_LIST', payload: formattedCompetencies });
-    };
+        selectedCompetencies.forEach(competenceId => {
+            dispatch({ type: 'SET_REVIEW_COMPETENCE', payload: { competenceId } });
+        });
 
+        const removedCompetencies = competencies.filter(id => !selectedCompetencies.includes(id));
+
+        removedCompetencies.forEach(competenceId => removeCompetence(competenceId));
+    };
 
     useEffect(() => {
         if (competenciesDetails.length > 0) {
             const occupationalPromises = Promise.all(
                 competenciesDetails.map(({ occupationalGroupId }) =>
                     useFindOccupationalGroup(occupationalGroupId)
-                )
+                )   
             );
 
             const skillPromises = Promise.all(
@@ -512,12 +520,14 @@ export function ReviewScaleAndCriteriaForm() {
         return `${day}/${month}/${year}`;
     }
 
+    console.log("competenciesDetails",competenciesDetails);
     if (isLoadingReviewScaleAndCriteriaData) {
         return (
             <PageChange />
         );
     }
-
+    const competenceValue = competencies ? competencies : latestreviewScaleAndCriteriaData;
+    console.log("competenceValue",competenceValue);
     return (
         <>
             <Card>
@@ -547,50 +557,58 @@ export function ReviewScaleAndCriteriaForm() {
                             {competencies.length > 0 ? (
                                 <>
                                     <h3>Detalhes das Competências:</h3>
-                                    
                                     {competenciesDetails.map((competency, index) => (
                                         <div key={competency.id}>
                                             <p>
-                                                <strong>Nome:</strong> {competency.competencieTypeName || "Carregando..."}
+                                                <strong>Nome:</strong> {competency.competencieTypeName ?? "Carregando..."}
                                             </p>
                                             <p>
-                                                <strong>Descrição:</strong> {competency.description || "Carregando..."}
+                                                <strong>Descrição:</strong> {competency.description ?? "Carregando..."}
                                             </p>
                                             <p>
                                                 <strong>Grupo Ocupacional:</strong>{" "}
-                                                {occupationalGroups[index]?.competencieName || "Carregando..."}
+                                                {occupationalGroups[index]?.competencieName ?? "Carregando..."}
                                             </p>
                                             <p>
                                                 <strong>Classificação da Habilidade:</strong>{" "}
-                                                {skillClassifications[index]?.competenceClassificationName || "Carregando..."}
+                                                {skillClassifications[index]?.competenceClassificationName ?? "Carregando..."}
                                             </p>
                                             <h4>Evidências Relacionadas:</h4>
-                                            <Table className="align-items-center table-flush" responsive>
-                                                <thead className="thead-light">
-                                                    <tr>
-                                                        <th>Descrição</th>
-                                                        <th>Status</th>
-                                                        <th>Adicionada Em</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {evidenceDataList.some(evidence => evidence.evidenceName == competency.id) ? (
-                                                        evidenceDataList
-                                                            .filter(evidence => evidence.evidenceName == competency.id)
-                                                            .map(evidence => (
-                                                                <tr key={evidence.id}>
-                                                                    <td>{evidence.description ?? "Carregando..."}</td>
-                                                                    <td>{evidence.status ? "Ativo" : "Inativo"}</td>
-                                                                    <td>{formatDate(evidence.createdAt) ?? "Não informado"}</td>
-                                                                </tr>
-                                                            ))
-                                                    ) : (
-                                                        <tr>
-                                                            <td colSpan="3">Nenhuma evidência encontrada.</td>
-                                                        </tr>
-                                                    )}
-                                                </tbody>
-                                            </Table>
+                                            <ToolkitProvider
+                                                data={evidenceDataList.filter(evidence => evidence.evidenceName == competency.id)}
+                                                keyField="id"
+                                                columns={evidenceColumns}
+                                                search
+                                            >
+                                                {(props) => (
+                                                    <div className="table-responsive">
+                                                        <div
+                                                            id="datatable-basic_filter"
+                                                            className="dataTables_filter pb-1 w-50"
+                                                        >
+                                                            <SearchBar
+                                                                className="form-control-sm"
+                                                                style={{
+                                                                    height: "40px",
+                                                                    width: 564,
+                                                                    fontSize: "16px",
+                                                                    padding: "10px",
+                                                                    borderRadius: "8px",
+                                                                }}
+                                                                placeholder="Pesquise por alguma evidência específica aqui ..."
+                                                                {...props.searchProps}
+                                                            />
+                                                        </div>
+                                                        <BootstrapTable
+                                                            {...props.baseProps}
+                                                            bootstrap4={true}
+                                                            pagination={pagination}
+                                                            bordered={false}
+                                                            selectRow={selectRow(competency.id)}
+                                                        />
+                                                    </div>
+                                                )}
+                                            </ToolkitProvider>
                                             <hr />
                                         </div>
                                     ))}
@@ -599,52 +617,6 @@ export function ReviewScaleAndCriteriaForm() {
                         </div>
                     </div>
                 </CardBody>
-            </Card>
-
-            <Card>
-                <CardHeader>
-                    <h3 className="mb-0">Evidecias</h3>
-                    {/* <p className="text-sm mb-0">
-                        This is an exmaple of data table using the well known
-                        react-bootstrap-table2 plugin. This is a minimal setup in
-                        order to get started fast.
-                    </p> */}
-                </CardHeader>
-                <ToolkitProvider
-                    data={evidenceDataTable || []}
-                    keyField="id"
-                    columns={evidenceColumns}
-                    search
-                >
-                    {(props) => (
-                        <div className="table-responsive">
-                            <div
-                                id="datatable-basic_filter"
-                                className="dataTables_filter pb-1 w-50"
-                            >
-                                <SearchBar
-                                    className="form-control-sm"
-                                    style={{
-                                        height: "40px",
-                                        width: 564,
-                                        fontSize: "16px",
-                                        padding: "10px",
-                                        borderRadius: "8px",
-                                    }}
-                                    placeholder="Pesquise por alguma evidência expecifica aqui ..."
-                                    {...props.searchProps}
-                                />
-                            </div>
-                            <BootstrapTable
-                                {...props.baseProps}
-                                bootstrap4={true}
-                                pagination={pagination}
-                                bordered={false}
-                                selectRow={selectRow}
-                            />
-                        </div>
-                    )}
-                </ToolkitProvider>
             </Card>
             <Card>
                 <CardHeader>

--- a/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
+++ b/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
@@ -12,6 +12,7 @@ import {
     ListGroupItem,
     Table,
 } from "reactstrap";
+// import { useSelector } from 'react-redux';
 import { ModelSelectionReviewContext } from "../../../../../../contexts/PerformanceContext/ModelSelectionReviewContext";
 import { initialState, formReducer } from '../../../../../../reducers/ReviewForms/ReviewScaleAndCriteriaFormReducer';
 import PageChange from "../../../../../PageChange/PageChange";
@@ -64,29 +65,50 @@ export function ReviewScaleAndCriteriaForm() {
     const [selectedIds, setSelectedIds] = useState([]);
 
     // Configuração para seleção de linhas
-    const selectRow = (competenceId) => ({
-        mode: "checkbox",
-        clickToSelect: true,
-        onSelect: (row, isSelected) => {
-            console.log(row, isSelected, competenceId);
-            if (isSelected) {
-                dispatch({ type: "SET_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
-            } else {
-                dispatch({ type: "REMOVE_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
-            }
-        },
-        onSelectAll: (isSelect, rows) => {
-            if (isSelect) {
-                rows.forEach(row => {
-                    dispatch({ type: "SET_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
-                });
-            } else {
-                rows.forEach(row => {
-                    dispatch({ type: "REMOVE_REVIEW_EVIDENCE", payload: { competenceId, evidenceId: row.id } });
-                });
-            }
-        }
-    });
+    const selectRow = (competenceId) => {
+        // Acesse os dados do reducer através de state
+        const selectedEvidenceIds = getSelectedEvidenceIds(
+            competenceId,
+            state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
+        );
+
+        return {
+            mode: "checkbox",
+            clickToSelect: true,
+            selected: selectedEvidenceIds, // Linhas que já devem estar selecionadas
+            onSelect: (row, isSelected) => {
+                console.log(row, isSelected, competenceId);
+                if (isSelected) {
+                    dispatch({
+                        type: "SET_REVIEW_EVIDENCE",
+                        payload: { competenceId, evidenceId: row.id },
+                    });
+                } else {
+                    dispatch({
+                        type: "REMOVE_REVIEW_EVIDENCE",
+                        payload: { competenceId, evidenceId: row.id },
+                    });
+                }
+            },
+            onSelectAll: (isSelect, rows) => {
+                if (isSelect) {
+                    rows.forEach(row => {
+                        dispatch({
+                            type: "SET_REVIEW_EVIDENCE",
+                            payload: { competenceId, evidenceId: row.id },
+                        });
+                    });
+                } else {
+                    rows.forEach(row => {
+                        dispatch({
+                            type: "REMOVE_REVIEW_EVIDENCE",
+                            payload: { competenceId, evidenceId: row.id },
+                        });
+                    });
+                }
+            },
+        };
+    };
 
     const removeCompetence = (competenceId) => {
         dispatch({ type: 'REMOVE_REVIEW_COMPETENCE', payload: { competenceId } });
@@ -322,12 +344,9 @@ export function ReviewScaleAndCriteriaForm() {
                             },
                         });
 
-                        latestreviewScaleAndCriteriaData.current = parsedData; // Atualiza a ref para os dados carregados
+                        latestreviewScaleAndCriteriaData.current = parsedData; 
                         setCompetencies(parsedData.reviewCompetenceEvidenceData.map(c => c.competenceId));
-                        console.log("Competencies Array:", parsedData.reviewCompetenceEvidenceData.map(c => c.competenceId));
-                       
-                        // setCompetencies(parsedData.reviewCompetenceEvidenceData);
-                        // console.log("parsedData", parsedData.reviewCompetenceEvidenceData);
+
                     }
                 } else {
                     dispatch({ type: 'RESET_REVIEW_STATE' }); // Limpa o estado para evitar inconsistências
@@ -340,6 +359,12 @@ export function ReviewScaleAndCriteriaForm() {
         };
         loadreviewScaleAndCriteriaData();
     }, []);
+
+    const getSelectedEvidenceIds = (competenceId, reviewCompetenceEvidenceData) => {
+        const competenceData = reviewCompetenceEvidenceData.find(item => item.competenceId === competenceId);
+        return competenceData ? competenceData.evidence.map(e => e.id) : [];
+    };
+
 
     // Atualize a lógica de persistência para incluir verificações e evitar sobrescrever valores críticos
     useEffect(() => {
@@ -369,7 +394,7 @@ export function ReviewScaleAndCriteriaForm() {
 
     const [competenciesDataList, setCompetenciesDataList] = useState([]);
     const [competenciesDetails, setCompetenciesDetails] = useState([]);
-    
+
     const [occupationalGroups, setOccupationalGroups] = useState([]);
     const [skillClassifications, setSkillClassifications] = useState([]);
     const [evidenceDataList, setEvidenceDataList] = useState([]);
@@ -400,35 +425,29 @@ export function ReviewScaleAndCriteriaForm() {
     }, [competencies]);
 
     const handleCompetenciesChange = (e) => {
-        // Converte as opções selecionadas em array
         const selectedOptions = Array.from(e.target.selectedOptions);
-        
-        // Se houver opções selecionadas, mapeia para números; senão, usa o valor padrão.
-        const selectedCompetencies = selectedOptions.length > 0 
-          ? selectedOptions.map(option => Number(option.value))
-          : competenceValue;
-      
-        console.log("selectedCompetencies", selectedCompetencies);
-      
+
+        const selectedCompetencies = selectedOptions.length > 0
+            ? selectedOptions.map(option => Number(option.value))
+            : competenceValue;
+
         setCompetencies(selectedCompetencies);
-      
-        // Para cada competência selecionada, atualiza o reducer
+
         selectedCompetencies.forEach(competenceId => {
-          dispatch({ type: 'SET_REVIEW_COMPETENCE', payload: { competenceId } });
+            dispatch({ type: 'SET_REVIEW_COMPETENCE', payload: { competenceId } });
         });
-      
-        // Calcula as competências removidas (aquelas que estavam no estado anterior mas não foram selecionadas agora)
+
         const removedCompetencies = competencies.filter(id => !selectedCompetencies.includes(id));
         removedCompetencies.forEach(competenceId => removeCompetence(competenceId));
-      };
-      
+    };
+
 
     useEffect(() => {
         if (competenciesDetails.length > 0) {
             const occupationalPromises = Promise.all(
                 competenciesDetails.map(({ occupationalGroupId }) =>
                     useFindOccupationalGroup(occupationalGroupId)
-                )   
+                )
             );
 
             const skillPromises = Promise.all(
@@ -531,16 +550,13 @@ export function ReviewScaleAndCriteriaForm() {
         return `${day}/${month}/${year}`;
     }
 
-    console.log("competenciesDetails",competenciesDetails);
     if (isLoadingReviewScaleAndCriteriaData) {
         return (
             <PageChange />
         );
     }
     const competenceValue = competencies ? competencies : latestreviewScaleAndCriteriaData;
-    // const competenceValue = [1];
-    console.log("competenceValue",competenceValue);
-    console.log("competencies", competencies);
+
     return (
         <>
             <Card>
@@ -567,7 +583,7 @@ export function ReviewScaleAndCriteriaForm() {
                             </Col>
                         </div>
                         <div>
-                            {competencies.length > 0 ? (
+                            {competencies.length > 0 && (
                                 <>
                                     <h3>Detalhes das Competências:</h3>
                                     {competenciesDetails.map((competency, index) => (
@@ -595,10 +611,7 @@ export function ReviewScaleAndCriteriaForm() {
                                             >
                                                 {(props) => (
                                                     <div className="table-responsive">
-                                                        <div
-                                                            id="datatable-basic_filter"
-                                                            className="dataTables_filter pb-1 w-50"
-                                                        >
+                                                        <div id="datatable-basic_filter" className="dataTables_filter pb-1 w-50">
                                                             <SearchBar
                                                                 className="form-control-sm"
                                                                 style={{
@@ -614,7 +627,7 @@ export function ReviewScaleAndCriteriaForm() {
                                                         </div>
                                                         <BootstrapTable
                                                             {...props.baseProps}
-                                                            bootstrap4={true}
+                                                            bootstrap4
                                                             pagination={pagination}
                                                             bordered={false}
                                                             selectRow={selectRow(competency.id)}
@@ -626,7 +639,7 @@ export function ReviewScaleAndCriteriaForm() {
                                         </div>
                                     ))}
                                 </>
-                            ) : null}
+                            )}
                         </div>
                     </div>
                 </CardBody>

--- a/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
+++ b/components/Forms/PerformanceForms/ReviewsForms/PerformanceReview/FormPerWizardSession/ReviewScaleAndCriteriaForm.js
@@ -323,9 +323,11 @@ export function ReviewScaleAndCriteriaForm() {
                         });
 
                         latestreviewScaleAndCriteriaData.current = parsedData; // Atualiza a ref para os dados carregados
-
+                        setCompetencies(parsedData.reviewCompetenceEvidenceData.map(c => c.competenceId));
+                        console.log("Competencies Array:", parsedData.reviewCompetenceEvidenceData.map(c => c.competenceId));
+                       
                         // setCompetencies(parsedData.reviewCompetenceEvidenceData);
-                        console.log("parsedData", parsedData.reviewCompetenceEvidenceData);
+                        // console.log("parsedData", parsedData.reviewCompetenceEvidenceData);
                     }
                 } else {
                     dispatch({ type: 'RESET_REVIEW_STATE' }); // Limpa o estado para evitar inconsistências
@@ -398,19 +400,28 @@ export function ReviewScaleAndCriteriaForm() {
     }, [competencies]);
 
     const handleCompetenciesChange = (e) => {
-        const selectedCompetencies = Array.from(e.target.selectedOptions).map(option => Number(option.value));
-
-        console.log("selectedCompetencies",selectedCompetencies);
-
+        // Converte as opções selecionadas em array
+        const selectedOptions = Array.from(e.target.selectedOptions);
+        
+        // Se houver opções selecionadas, mapeia para números; senão, usa o valor padrão.
+        const selectedCompetencies = selectedOptions.length > 0 
+          ? selectedOptions.map(option => Number(option.value))
+          : competenceValue;
+      
+        console.log("selectedCompetencies", selectedCompetencies);
+      
         setCompetencies(selectedCompetencies);
+      
+        // Para cada competência selecionada, atualiza o reducer
         selectedCompetencies.forEach(competenceId => {
-            dispatch({ type: 'SET_REVIEW_COMPETENCE', payload: { competenceId } });
+          dispatch({ type: 'SET_REVIEW_COMPETENCE', payload: { competenceId } });
         });
-
+      
+        // Calcula as competências removidas (aquelas que estavam no estado anterior mas não foram selecionadas agora)
         const removedCompetencies = competencies.filter(id => !selectedCompetencies.includes(id));
-
         removedCompetencies.forEach(competenceId => removeCompetence(competenceId));
-    };
+      };
+      
 
     useEffect(() => {
         if (competenciesDetails.length > 0) {
@@ -527,7 +538,9 @@ export function ReviewScaleAndCriteriaForm() {
         );
     }
     const competenceValue = competencies ? competencies : latestreviewScaleAndCriteriaData;
+    // const competenceValue = [1];
     console.log("competenceValue",competenceValue);
+    console.log("competencies", competencies);
     return (
         <>
             <Card>
@@ -546,7 +559,7 @@ export function ReviewScaleAndCriteriaForm() {
                                     className="form-control"
                                     data-minimum-results-for-search="Infinity"
                                     options={{ placeholder: "Selecione uma ou mais competências" }}
-                                    value={competencies}
+                                    value={competencies || competenceValue}
                                     multiple
                                     onChange={handleCompetenciesChange}
                                     data={competenciesDataList || []}

--- a/reducers/ReviewForms/ReviewScaleAndCriteriaFormReducer.js
+++ b/reducers/ReviewForms/ReviewScaleAndCriteriaFormReducer.js
@@ -15,7 +15,7 @@ export const initialState = {
         rulerOptionSelected: null,
         reviewRulerOptionSelected: null,
         reviewRulerOptionSelectedState: null,
-        reviewEvidenceData: [],
+        reviewCompetenceEvidenceData: [],
         reviewCompetenceData: [],
     },
 };
@@ -118,16 +118,16 @@ export const formReducer = (state, action) => {
                     rulerOptionSelected: Array.isArray(action.payload) ? action.payload : [],
                 },
             };
-        case 'SET_REVIEW_EVIDENCE_DATA_LIST':
-            return {
-                ...state,
-                reviewScaleAndCriteriaData: {
-                    ...state.reviewScaleAndCriteriaData,
-                    reviewEvidenceData: Array.isArray(action.payload)
-                        ? action.payload // Para onSelectAll
-                        : action.payload(state), // Para onSelect
-                },
-            };
+        // case 'SET_REVIEW_EVIDENCE_DATA_LIST':
+        //     return {
+        //         ...state,
+        //         reviewScaleAndCriteriaData: {
+        //             ...state.reviewScaleAndCriteriaData,
+        //             reviewEvidenceData: Array.isArray(action.payload)
+        //                 ? action.payload // Para onSelectAll
+        //                 : action.payload(state), // Para onSelect
+        //         },
+        //     };
         case 'SET_REVIEW_COMPETENCIE_DATA_LIST':
             return {
                 ...state,
@@ -136,6 +136,77 @@ export const formReducer = (state, action) => {
                     reviewCompetenceData: Array.isArray(action.payload) ? action.payload : [],
                 },
             };
+        case 'SET_REVIEW_COMPETENCE': {
+            const { competenceId } = action.payload;
+            // Verifica se a competência já está na lista
+            const exists = state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
+                .some(item => item.competenceId === competenceId);
+
+            if (!exists) {
+                return {
+                    ...state,
+                    reviewScaleAndCriteriaData: {
+                        ...state.reviewScaleAndCriteriaData,
+                        reviewCompetenceEvidenceData: [
+                            ...state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData,
+                            { competenceId, evidence: [] }
+                        ],
+                    },
+                };
+            }
+            return state; // Se já existir, não faz nada
+        }
+
+        case 'SET_REVIEW_EVIDENCE': {
+            const { competenceId, evidenceId } = action.payload;
+            return {
+                ...state,
+                reviewScaleAndCriteriaData: {
+                    ...state.reviewScaleAndCriteriaData,
+                    reviewCompetenceEvidenceData: state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
+                        .map(item =>
+                            item.competenceId === competenceId
+                                ? {
+                                    ...item,
+                                    evidence: [...item.evidence, { id: evidenceId }]
+                                }
+                                : item
+                        ),
+                },
+            };
+        }
+
+        case 'REMOVE_REVIEW_EVIDENCE': {
+            const { competenceId, evidenceId } = action.payload;
+            return {
+                ...state,
+                reviewScaleAndCriteriaData: {
+                    ...state.reviewScaleAndCriteriaData,
+                    reviewCompetenceEvidenceData: state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
+                        .map(item =>
+                            item.competenceId === competenceId
+                                ? {
+                                    ...item,
+                                    evidence: item.evidence.filter(e => e.id !== evidenceId)
+                                }
+                                : item
+                        ),
+                },
+            };
+        }
+
+        case 'REMOVE_REVIEW_COMPETENCE': {
+            const { competenceId } = action.payload;
+            return {
+                ...state,
+                reviewScaleAndCriteriaData: {
+                    ...state.reviewScaleAndCriteriaData,
+                    reviewCompetenceEvidenceData: state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
+                        .filter(item => item.competenceId !== competenceId),
+                },
+            };
+        }
+
         case 'CLEAR_FORM':
             return initialState;
 

--- a/reducers/ReviewForms/ReviewScaleAndCriteriaFormReducer.js
+++ b/reducers/ReviewForms/ReviewScaleAndCriteriaFormReducer.js
@@ -118,16 +118,6 @@ export const formReducer = (state, action) => {
                     rulerOptionSelected: Array.isArray(action.payload) ? action.payload : [],
                 },
             };
-        // case 'SET_REVIEW_EVIDENCE_DATA_LIST':
-        //     return {
-        //         ...state,
-        //         reviewScaleAndCriteriaData: {
-        //             ...state.reviewScaleAndCriteriaData,
-        //             reviewEvidenceData: Array.isArray(action.payload)
-        //                 ? action.payload // Para onSelectAll
-        //                 : action.payload(state), // Para onSelect
-        //         },
-        //     };
         case 'SET_REVIEW_COMPETENCIE_DATA_LIST':
             return {
                 ...state,
@@ -138,7 +128,7 @@ export const formReducer = (state, action) => {
             };
         case 'SET_REVIEW_COMPETENCE': {
             const { competenceId } = action.payload;
-            // Verifica se a competência já está na lista
+
             const exists = state.reviewScaleAndCriteriaData.reviewCompetenceEvidenceData
                 .some(item => item.competenceId === competenceId);
 
@@ -154,9 +144,8 @@ export const formReducer = (state, action) => {
                     },
                 };
             }
-            return state; // Se já existir, não faz nada
+            return state; 
         }
-
         case 'SET_REVIEW_EVIDENCE': {
             const { competenceId, evidenceId } = action.payload;
             return {
@@ -175,7 +164,6 @@ export const formReducer = (state, action) => {
                 },
             };
         }
-
         case 'REMOVE_REVIEW_EVIDENCE': {
             const { competenceId, evidenceId } = action.payload;
             return {
@@ -194,7 +182,6 @@ export const formReducer = (state, action) => {
                 },
             };
         }
-
         case 'REMOVE_REVIEW_COMPETENCE': {
             const { competenceId } = action.payload;
             return {
@@ -206,7 +193,6 @@ export const formReducer = (state, action) => {
                 },
             };
         }
-
         case 'CLEAR_FORM':
             return initialState;
 


### PR DESCRIPTION
Consegui finalizar a questão de puxar as informações das competências selecionadas e de suas evidências e mostrar novamente elas , assim mantendo o fluxo de passos sem perder nenhuma informação escolhida pelo usuário. Dei uma organizada no código em questão dos consoles e comentários que havia colocado anteriormente. Fiz de uma forma em que eu apenas deixasse as os id's armazenados no sessão do usuário como antes, e quando tiver dados armazenados ele puxa esses id's das competências e coloca novamente no select, para ele fazer a busca das informações pela api e também buscar as informações do grupo operacional e classificação da habilidade que é salvo apenas por id (como se fosse o próprio usuário fazendo e escolhendo a competência no select. Assim evitei ter que adicionar mais effect's que já existiam para fazer a mesma coisa), após isso é puxado o id da evidência e é comparado para ver se é a mesma que foi selecionada na linha da tabela, assim marcando o checkbox presente.